### PR TITLE
docs: add an example of pseudo-element's content

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ yarn add -D @greenlabs/res-tailwindcss
 ## Example
 
 ```rescript
-<div className=%twc("flex justify-center items-center")>
+<div className=%twc("flex justify-center items-center after:content-['Hello_World']")>
   ...
 </div>
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Plus, the arbitrary values in the JIT mode of Tailwindcss are supported!
 <div className=%twc("grid-cols-[1fr,700px,2fr]")> ... </div>
 <div className=%twc("translate-x-[calc(-50%+27px)]")> ... </div>
 <div className=%twc("!pb-[270px]")> ... </div>
+<div className=%twc("after:content-['Hello_World']")> ... </div>
 ```
 
 ## Install


### PR DESCRIPTION
Add an example of `pseudo-element's content` that was made available by the #21 PR.