### PR TITLE
build linking statically

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-latest]
         ocaml-compiler:
           - 4.12.1
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-latest]
         ocaml-compiler:
           - 4.12.1
 
@@ -108,7 +108,7 @@ jobs:
   publish:
     needs: [build_linux, build_macos, build_windows]
     name: (only on release) Publish
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -120,7 +120,7 @@ jobs:
         if: success()
         uses: actions/download-artifact@master
         with:
-          name: ubuntu-18.04
+          name: ubuntu-latest
           path: binaries/linux
 
       - name: Download macOS artifacts

--- a/.github/workflows/publish_prerelease.yml
+++ b/.github/workflows/publish_prerelease.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-latest]
         ocaml-compiler:
           - 4.12.1
 
@@ -114,7 +114,7 @@ jobs:
   publish:
     needs: [build_linux, build_macos, build_windows]
     name: (only on release) Publish
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -126,7 +126,7 @@ jobs:
         if: success()
         uses: actions/download-artifact@master
         with:
-          name: ubuntu-18.04
+          name: ubuntu-latest
           path: binaries/linux
 
       - name: Download macOS artifacts


### PR DESCRIPTION
It fixes the issue where the build error occurred in GLIBC incompatibility such as Vercel CI.